### PR TITLE
Remove auth CTA and Form Four route UI

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -80,14 +80,6 @@ function SiteHeader() {
         >
           <SearchIcon className="size-[18px]" />
         </Link>
-        <Button
-          size="lg"
-          className="h-11 rounded-full bg-brand-ink px-5 text-[13px] font-semibold text-white hover:bg-brand-ink/90"
-          type="button"
-        >
-          <UserIcon className="size-4" />
-          Ingia / Jiunge
-        </Button>
       </div>
     </header>
   )
@@ -324,24 +316,6 @@ function SearchIcon({ className = "" }: { className?: string }) {
     >
       <circle cx={11} cy={11} r={7} />
       <path d="m20 20-3.5-3.5" />
-    </svg>
-  )
-}
-
-function UserIcon({ className = "" }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      className={className}
-      aria-hidden
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx={12} cy={8} r={4} />
-      <path d="M4 21c1.5-4 5-6 8-6s6.5 2 8 6" />
     </svg>
   )
 }

--- a/components/search/programme-card.tsx
+++ b/components/search/programme-card.tsx
@@ -5,11 +5,10 @@ import type { ReactNode } from "react"
 import { useState } from "react"
 import type { useQuery } from "convex/react"
 
-import { familyMeta, formFourLabel } from "@/components/search/search-config"
+import { familyMeta } from "@/components/search/search-config"
 import {
   ArrowRightIcon,
   BookmarkIcon,
-  CheckIcon,
   ClockIcon,
   PinIcon,
 } from "@/components/search/search-icons"
@@ -74,12 +73,6 @@ export function ProgrammeCard({ programme }: { programme: ProgrammeSearchResult 
           </Tag>
         ) : null}
         {programme.feesIfAvailable ? <Tag>{programme.feesIfAvailable}</Tag> : null}
-        <Tag tone={programme.suitableForFormFourLeaver === "yes" ? "green" : "ink"}>
-          {programme.suitableForFormFourLeaver === "yes" ? (
-            <CheckIcon className="size-3.5" />
-          ) : null}
-          {formFourLabel(programme.suitableForFormFourLeaver)}
-        </Tag>
       </div>
 
       {programme.minimumEntryRequirements ? (

--- a/components/search/search-config.ts
+++ b/components/search/search-config.ts
@@ -35,7 +35,7 @@ export const trendingQueries = [
   "Hotel management",
 ] as const
 
-export type SearchFilterKey = "family" | "formFour" | "level" | "region"
+export type SearchFilterKey = "family" | "level" | "region"
 
 export type ActiveFilter = {
   key: string
@@ -84,18 +84,6 @@ export function familyMeta(key?: string) {
     swahili: "",
     mark: "•",
   }
-}
-
-export function formFourLabel(value?: string) {
-  if (value === "yes") {
-    return "Can join after Form Four"
-  }
-
-  if (value === "no") {
-    return "A-level required"
-  }
-
-  return "Verify entry route"
 }
 
 export function isActiveFilter(

--- a/components/search/search-config.ts
+++ b/components/search/search-config.ts
@@ -88,7 +88,7 @@ export function familyMeta(key?: string) {
 
 export function formFourLabel(value?: string) {
   if (value === "yes") {
-    return "Form Four direct"
+    return "Can join after Form Four"
   }
 
   if (value === "no") {

--- a/components/search/search-filters.tsx
+++ b/components/search/search-filters.tsx
@@ -51,9 +51,11 @@ export function SearchFilters({
             type="button"
           >
             <span>
-              <span className="block text-[13.5px] font-semibold">Form Four direct</span>
+              <span className="block text-[13.5px] font-semibold">
+                Can join after Form Four
+              </span>
               <span className="mt-0.5 block text-[12px] text-brand-ink/55">
-                Show programmes you can join straight after CSEE.
+                Programmes with a CSEE entry route.
               </span>
             </span>
             <span

--- a/components/search/search-filters.tsx
+++ b/components/search/search-filters.tsx
@@ -12,7 +12,6 @@ type SearchFiltersProps = {
   activeFilters: ActiveFilter[]
   awardLevel: string
   family?: string
-  formFourOnly: boolean
   region: string
   clearAllFilters: () => void
   setFilter: (key: SearchFilterKey, value: string | null) => void
@@ -22,7 +21,6 @@ export function SearchFilters({
   activeFilters,
   awardLevel,
   family,
-  formFourOnly,
   region,
   clearAllFilters,
   setFilter,
@@ -41,35 +39,6 @@ export function SearchFilters({
               Clear all
             </button>
           ) : null}
-        </div>
-
-        <div className="border-b border-brand-ink/8 px-5 py-5">
-          <button
-            aria-pressed={formFourOnly}
-            className="flex w-full cursor-pointer items-center justify-between gap-3 text-left"
-            onClick={() => setFilter("formFour", formFourOnly ? "false" : "yes")}
-            type="button"
-          >
-            <span>
-              <span className="block text-[13.5px] font-semibold">
-                Can join after Form Four
-              </span>
-              <span className="mt-0.5 block text-[12px] text-brand-ink/55">
-                Programmes with a CSEE entry route.
-              </span>
-            </span>
-            <span
-              className={`relative h-6 w-10 shrink-0 rounded-full transition ${
-                formFourOnly ? "bg-brand-blue" : "bg-brand-ink/15"
-              }`}
-            >
-              <span
-                className={`absolute top-0.5 size-5 rounded-full bg-white shadow transition ${
-                  formFourOnly ? "left-[18px]" : "left-0.5"
-                }`}
-              />
-            </span>
-          </button>
         </div>
 
         <FilterSection title="Field of study" hint="Eneo la masomo">

--- a/components/search/search-header.tsx
+++ b/components/search/search-header.tsx
@@ -56,12 +56,13 @@ export function SearchHeader({
             </Link>
           </nav>
 
-          <Button
-            className="h-10 rounded-full bg-brand-ink px-5 text-[13px] font-semibold text-white hover:bg-brand-ink/90"
-            type="button"
+          <Link
+            href="/search"
+            aria-label="Search programmes"
+            className="grid size-10 place-items-center rounded-full text-brand-ink transition-colors hover:bg-brand-ink/5 md:hidden"
           >
-            Ingia / Jiunge
-          </Button>
+            <SearchIcon className="size-[18px]" />
+          </Link>
         </div>
       </header>
 

--- a/components/search/search-icons.tsx
+++ b/components/search/search-icons.tsx
@@ -59,14 +59,6 @@ export function ClockIcon({ className = "" }: { className?: string }) {
   )
 }
 
-export function CheckIcon({ className = "" }: { className?: string }) {
-  return (
-    <Icon className={className}>
-      <path d="M5 12l5 5L20 7" />
-    </Icon>
-  )
-}
-
 export function BookmarkIcon({ className = "" }: { className?: string }) {
   return (
     <Icon className={className}>

--- a/components/search/search-results-client.tsx
+++ b/components/search/search-results-client.tsx
@@ -102,7 +102,7 @@ export function SearchResultsClient() {
     },
     formFourOnly && {
       key: "formFour",
-      label: "Form Four direct",
+      label: "Can join after Form Four",
       clear: () => setFilter("formFour", "false"),
     },
   ].filter(isActiveFilter)

--- a/components/search/search-results-client.tsx
+++ b/components/search/search-results-client.tsx
@@ -32,8 +32,7 @@ export function SearchResultsClient() {
   const family = searchParams.get("family") ?? undefined
   const awardLevel = searchParams.get("level") ?? "all"
   const region = searchParams.get("region") ?? ""
-  const formFourOnly = searchParams.get("formFour") === "yes"
-  const resultSetKey = `${queryFromUrl}|${family ?? ""}|${awardLevel}|${region}|${formFourOnly}`
+  const resultSetKey = `${queryFromUrl}|${family ?? ""}|${awardLevel}|${region}`
   const [resultLimitState, setResultLimitState] = useState({
     key: resultSetKey,
     limit: INITIAL_RESULT_LIMIT,
@@ -50,13 +49,12 @@ export function SearchResultsClient() {
   }, [awardLevel, family, region])
 
   const activeQuery = queryFromUrl
-  const hasFilters = Boolean(family) || awardLevel !== "all" || Boolean(region) || formFourOnly
+  const hasFilters = Boolean(family) || awardLevel !== "all" || Boolean(region)
 
   const searchArgs = activeQuery
     ? {
         query: activeQuery,
         filters: hasFilters ? filters : undefined,
-        formFourOnly,
         limit: resultLimit,
       }
     : "skip"
@@ -65,7 +63,6 @@ export function SearchResultsClient() {
     ? {
         query: activeQuery,
         filters: hasFilters ? filters : undefined,
-        formFourOnly,
         maxCount: 1000,
       }
     : "skip"
@@ -100,11 +97,6 @@ export function SearchResultsClient() {
       label: region,
       clear: () => setFilter("region", null),
     },
-    formFourOnly && {
-      key: "formFour",
-      label: "Can join after Form Four",
-      clear: () => setFilter("formFour", "false"),
-    },
   ].filter(isActiveFilter)
 
   function routeWith(nextParams: URLSearchParams) {
@@ -120,7 +112,6 @@ export function SearchResultsClient() {
     routeWith(
       updateParams(searchParams, {
         family: null,
-        formFour: null,
         level: null,
         region: null,
       }),
@@ -162,7 +153,6 @@ export function SearchResultsClient() {
           activeFilters={activeFilters}
           awardLevel={awardLevel}
           family={family}
-          formFourOnly={formFourOnly}
           region={region}
           clearAllFilters={clearAllFilters}
           setFilter={setFilter}


### PR DESCRIPTION
## Summary
- Remove the unused Ingia / Jiunge auth CTA from the homepage and search headers
- Remove the Form Four route filter widget from the search sidebar
- Remove the Form Four route badge from programme cards
- Stop applying the hidden formFour URL filter in search results

## Validation
- bun run typecheck
- bun run lint
- bun run build