### PR TITLE
Fix mobile search result layout

### DIFF
--- a/components/search/programme-card.tsx
+++ b/components/search/programme-card.tsx
@@ -22,30 +22,32 @@ export function ProgrammeCard({ programme }: { programme: ProgrammeSearchResult 
   const meta = familyMeta(programme.courseFamily)
 
   return (
-    <article className="group rounded-2xl border border-brand-ink/10 bg-white p-5 transition hover:border-brand-blue/35 hover:shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)]">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 items-start gap-3">
+    <article className="group max-w-full overflow-hidden rounded-2xl border border-brand-ink/10 bg-white p-4 transition hover:border-brand-blue/35 hover:shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)] sm:p-5">
+      <div className="flex min-w-0 items-start justify-between gap-3 sm:gap-4">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
           <InstitutionLogo
             fallback={meta.mark}
             institutionName={programme.institutionName}
             logoUrl={programme.institutionLogoUrl}
           />
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2 text-[11.5px] font-semibold uppercase tracking-[0.14em] text-brand-ink/45">
-              <span>{programme.awardLevel}</span>
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-[10.5px] font-semibold uppercase tracking-[0.11em] text-brand-ink/45 sm:gap-2 sm:text-[11.5px] sm:tracking-[0.14em]">
+              <span className="min-w-0 max-w-full break-words">{programme.awardLevel}</span>
               <span className="size-1 rounded-full bg-brand-ink/30" />
-              <span>{programme.regulator}</span>
+              <span className="min-w-0 max-w-full break-words">{programme.regulator}</span>
               {programme.ownershipType ? (
                 <>
                   <span className="size-1 rounded-full bg-brand-ink/30" />
-                  <span>{programme.ownershipType}</span>
+                  <span className="min-w-0 max-w-full break-words">
+                    {programme.ownershipType}
+                  </span>
                 </>
               ) : null}
             </div>
-            <h3 className="mt-1.5 truncate text-[17px] font-bold tracking-tight">
+            <h3 className="mt-1.5 line-clamp-2 break-words text-[17px] font-bold tracking-tight">
               {programme.programmeName}
             </h3>
-            <p className="mt-0.5 truncate text-[13.5px] font-medium text-brand-ink/65">
+            <p className="mt-0.5 line-clamp-2 break-words text-[13.5px] font-medium text-brand-ink/65">
               {programme.institutionName}
             </p>
           </div>
@@ -59,16 +61,12 @@ export function ProgrammeCard({ programme }: { programme: ProgrammeSearchResult 
         </button>
       </div>
 
-      <div className="mt-4 flex flex-wrap gap-1.5 text-[12px] text-brand-ink/70">
+      <div className="mt-4 flex min-w-0 flex-wrap gap-1.5 text-[12px] text-brand-ink/70">
         {programme.region ? (
-          <Tag>
-            <PinIcon className="size-3.5" />
-            {programme.region}
-          </Tag>
+          <Tag icon={<PinIcon className="size-3.5 shrink-0" />}>{programme.region}</Tag>
         ) : null}
         {programme.duration ? (
-          <Tag>
-            <ClockIcon className="size-3.5" />
+          <Tag icon={<ClockIcon className="size-3.5 shrink-0" />}>
             {programme.duration} years
           </Tag>
         ) : null}
@@ -80,19 +78,19 @@ export function ProgrammeCard({ programme }: { programme: ProgrammeSearchResult 
           <p className="text-[10.5px] font-semibold uppercase tracking-[0.18em] text-brand-ink/40">
             Entry requirements
           </p>
-          <p className="mt-1.5 line-clamp-2 text-[13px] leading-6 text-brand-ink/70">
+          <p className="mt-1.5 line-clamp-2 break-words text-[13px] leading-6 text-brand-ink/70">
             {programme.minimumEntryRequirements}
           </p>
         </div>
       ) : null}
 
-      <div className="mt-4 flex items-center justify-between gap-3">
-        <p className="text-[11.5px] text-brand-ink/45">
+      <div className="mt-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="break-words text-[11.5px] text-brand-ink/45">
           Verified {programme.lastVerifiedDate}
           {programme.needsReview ? " · Needs review" : ""}
         </p>
         <button
-          className="inline-flex items-center gap-1.5 rounded-full bg-brand-ink px-4 py-2 text-[13px] font-semibold text-white transition hover:bg-brand-blue"
+          className="inline-flex w-full items-center justify-center gap-1.5 rounded-full bg-brand-ink px-4 py-2 text-[13px] font-semibold text-white transition hover:bg-brand-blue sm:w-auto"
           type="button"
         >
           View details
@@ -116,7 +114,7 @@ function InstitutionLogo({
 
   if (logoUrl && !failed) {
     return (
-      <div className="grid size-11 shrink-0 place-items-center overflow-hidden rounded-xl border border-brand-ink/10 bg-white p-1.5">
+      <div className="grid size-10 shrink-0 place-items-center overflow-hidden rounded-xl border border-brand-ink/10 bg-white p-1.5 sm:size-11">
         <Image
           alt={`${institutionName} logo`}
           className="max-h-full max-w-full object-contain"
@@ -132,7 +130,7 @@ function InstitutionLogo({
   }
 
   return (
-    <div className="grid size-11 shrink-0 place-items-center rounded-xl bg-brand-blue/10 font-mono text-[14px] font-semibold text-brand-blue">
+    <div className="grid size-10 shrink-0 place-items-center rounded-xl bg-brand-blue/10 font-mono text-[14px] font-semibold text-brand-blue sm:size-11">
       {fallback}
     </div>
   )
@@ -140,9 +138,11 @@ function InstitutionLogo({
 
 function Tag({
   children,
+  icon,
   tone = "neutral",
 }: {
   children: ReactNode
+  icon?: ReactNode
   tone?: "neutral" | "green" | "ink"
 }) {
   const tones = {
@@ -152,8 +152,11 @@ function Tag({
   }
 
   return (
-    <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 font-medium ${tones[tone]}`}>
-      {children}
+    <span
+      className={`inline-flex max-w-full min-w-0 items-center gap-1 truncate rounded-full px-2.5 py-1 font-medium ${tones[tone]}`}
+    >
+      {icon}
+      <span className="min-w-0 truncate">{children}</span>
     </span>
   )
 }

--- a/components/search/search-results-client.tsx
+++ b/components/search/search-results-client.tsx
@@ -148,7 +148,7 @@ export function SearchResultsClient() {
         onTrending={runTrending}
       />
 
-      <div className="mx-auto grid max-w-[1280px] gap-8 px-6 py-8 sm:px-8 lg:grid-cols-[19rem_1fr]">
+      <div className="mx-auto grid max-w-[1280px] gap-8 px-4 py-8 sm:px-6 lg:grid-cols-[19rem_1fr] lg:px-8">
         <SearchFilters
           activeFilters={activeFilters}
           awardLevel={awardLevel}
@@ -168,23 +168,23 @@ export function SearchResultsClient() {
           />
 
           {activeFilters.length > 0 ? (
-            <div className="mt-4 flex flex-wrap items-center gap-2">
+            <div className="mt-4 flex min-w-0 flex-wrap items-center gap-2">
               {activeFilters.map((filter) => (
                 <button
                   aria-label={`Remove ${filter.label} filter`}
-                  className="inline-flex items-center gap-1.5 rounded-full bg-brand-blue/10 px-3 py-1.5 text-[12px] font-medium text-brand-blue hover:bg-brand-blue/15"
+                  className="inline-flex max-w-full items-center gap-1.5 rounded-full bg-brand-blue/10 px-3 py-1.5 text-[12px] font-medium text-brand-blue hover:bg-brand-blue/15"
                   key={filter.key}
                   onClick={filter.clear}
                   type="button"
                 >
-                  {filter.label}
-                  <XIcon className="size-3" />
+                  <span className="min-w-0 truncate">{filter.label}</span>
+                  <XIcon className="size-3 shrink-0" />
                 </button>
               ))}
             </div>
           ) : null}
 
-          <div className="mt-5 grid gap-4">
+          <div className="mt-5 grid min-w-0 gap-4">
             {!activeQuery ? (
               <EmptyState />
             ) : isResultsLoading ? (
@@ -263,19 +263,19 @@ function SearchResultsHeader({
   resultCount?: number
 }) {
   return (
-    <div className="flex flex-wrap items-end justify-between gap-4 border-b border-brand-ink/8 pb-4">
-      <div>
+    <div className="flex min-w-0 flex-wrap items-end justify-between gap-4 border-b border-brand-ink/8 pb-4">
+      <div className="min-w-0">
         <p className="text-[12.5px] font-medium uppercase tracking-[0.16em] text-brand-blue">
           {isCountLoading
             ? "Searching"
             : `${count?.count ?? resultCount ?? 0}${count?.capped ? "+" : ""} matches`}
         </p>
-        <h2 className="mt-1 text-[22px] font-bold tracking-tight">
+        <h2 className="mt-1 break-words text-[22px] font-bold tracking-tight">
           {activeQuery ? `Results for "${activeQuery}"` : "All programmes"}
         </h2>
       </div>
       {inferredFamily ? (
-        <span className="rounded-full bg-brand-blue/10 px-3 py-1.5 text-[12px] font-medium text-brand-blue">
+        <span className="max-w-full shrink-0 truncate rounded-full bg-brand-blue/10 px-3 py-1.5 text-[12px] font-medium text-brand-blue">
           {familyMeta(inferredFamily).label}
         </span>
       ) : null}


### PR DESCRIPTION
## Summary
- constrain search result cards on mobile to prevent horizontal overflow
- allow long programme and institution names to wrap cleanly
- truncate long filter and fee chips inside their containers
- stack the details CTA on small screens

## Validation
- bun run typecheck
- bun run lint
- user confirmed the mobile page is fixed in browser

Note: bun run build was attempted once in the sandbox and failed only because Google Fonts could not be fetched. The later PR creation command accidentally triggered a build in the normal shell context, and that build completed successfully.
