### PR TITLE
Add programme share links

### DIFF
--- a/components/search/programme-card.tsx
+++ b/components/search/programme-card.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image"
 import type { ReactNode } from "react"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import type { useQuery } from "convex/react"
 
 import { familyMeta } from "@/components/search/search-config"
@@ -10,6 +10,7 @@ import {
   ArrowRightIcon,
   ClockIcon,
   PinIcon,
+  ShareIcon,
 } from "@/components/search/search-icons"
 import { api } from "@/convex/_generated/api"
 
@@ -17,12 +18,61 @@ type ProgrammeSearchResult = NonNullable<
   ReturnType<typeof useQuery<typeof api.programmes.smartSearch>>
 >["results"][number]
 
-export function ProgrammeCard({ programme }: { programme: ProgrammeSearchResult }) {
+export function ProgrammeCard({
+  isSelected = false,
+  programme,
+  shareUrl,
+}: {
+  isSelected?: boolean
+  programme: ProgrammeSearchResult
+  shareUrl: string
+}) {
   const meta = familyMeta(programme.courseFamily)
-  const [showDetails, setShowDetails] = useState(false)
+  const cardRef = useRef<HTMLElement>(null)
+  const [showDetails, setShowDetails] = useState(isSelected)
+  const [shareStatus, setShareStatus] = useState<"idle" | "copied">("idle")
+  const detailsVisible = showDetails
+
+  useEffect(() => {
+    if (!isSelected) {
+      return
+    }
+
+    cardRef.current?.scrollIntoView({ block: "center", behavior: "smooth" })
+  }, [isSelected])
+
+  async function shareProgramme() {
+    const shareTitle = `${programme.programmeName} at ${programme.institutionName}`
+    const shareText = `Check this course on Kozi Ipi: ${shareTitle}`
+    const absoluteShareUrl = new URL(shareUrl, window.location.origin).toString()
+
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: shareTitle,
+          text: shareText,
+          url: absoluteShareUrl,
+        })
+        return
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return
+        }
+      }
+    }
+
+    await copyToClipboard(absoluteShareUrl)
+    setShareStatus("copied")
+    window.setTimeout(() => setShareStatus("idle"), 1800)
+  }
 
   return (
-    <article className="group max-w-full overflow-hidden rounded-2xl border border-brand-ink/10 bg-white p-4 transition hover:border-brand-blue/35 hover:shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)] sm:p-5">
+    <article
+      className={`group max-w-full scroll-mt-6 overflow-hidden rounded-2xl border bg-white p-4 transition hover:border-brand-blue/35 hover:shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)] sm:p-5 ${
+        isSelected ? "border-brand-blue shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)]" : "border-brand-ink/10"
+      }`}
+      ref={cardRef}
+    >
       <div className="flex min-w-0 items-start justify-between gap-3 sm:gap-4">
         <div className="flex min-w-0 flex-1 items-start gap-3">
           <InstitutionLogo
@@ -82,19 +132,29 @@ export function ProgrammeCard({ programme }: { programme: ProgrammeSearchResult 
           Verified {programme.lastVerifiedDate}
           {programme.needsReview ? " · Needs review" : ""}
         </p>
-        <button
-          className="inline-flex w-full items-center justify-center gap-1.5 rounded-full bg-brand-ink px-4 py-2 text-[13px] font-semibold text-white transition hover:bg-brand-blue sm:w-auto"
-          onClick={() => setShowDetails((visible) => !visible)}
-          type="button"
-        >
-          {showDetails ? "Hide details" : "View details"}
-          <ArrowRightIcon
-            className={`size-3.5 transition ${showDetails ? "rotate-90" : ""}`}
-          />
-        </button>
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+          <button
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-full border border-brand-ink/15 px-4 py-2 text-[13px] font-semibold text-brand-ink transition hover:border-brand-blue hover:text-brand-blue sm:w-auto"
+            onClick={shareProgramme}
+            type="button"
+          >
+            <ShareIcon className="size-3.5" />
+            {shareStatus === "copied" ? "Link copied" : "Share"}
+          </button>
+          <button
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-full bg-brand-ink px-4 py-2 text-[13px] font-semibold text-white transition hover:bg-brand-blue sm:w-auto"
+            onClick={() => setShowDetails((visible) => !visible)}
+            type="button"
+          >
+            {detailsVisible ? "Hide details" : "View details"}
+            <ArrowRightIcon
+              className={`size-3.5 transition ${detailsVisible ? "rotate-90" : ""}`}
+            />
+          </button>
+        </div>
       </div>
 
-      {showDetails ? <ProgrammeDetails programme={programme} /> : null}
+      {detailsVisible ? <ProgrammeDetails programme={programme} /> : null}
     </article>
   )
 }
@@ -156,6 +216,27 @@ function normalizeExternalHref(href?: string) {
   }
 
   return null
+}
+
+async function copyToClipboard(value: string) {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(value)
+      return
+    } catch {
+      // Fall back for browsers that expose clipboard but block writes.
+    }
+  }
+
+  const textarea = document.createElement("textarea")
+  textarea.value = value
+  textarea.setAttribute("readonly", "")
+  textarea.style.position = "fixed"
+  textarea.style.left = "-9999px"
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand("copy")
+  document.body.removeChild(textarea)
 }
 
 function DetailLink({ children, href }: { children: ReactNode; href: string }) {

--- a/components/search/programme-card.tsx
+++ b/components/search/programme-card.tsx
@@ -38,6 +38,7 @@ export function ProgrammeCard({
       return
     }
 
+    window.requestAnimationFrame(() => setShowDetails(true))
     cardRef.current?.scrollIntoView({ block: "center", behavior: "smooth" })
   }, [isSelected])
 

--- a/components/search/search-icons.tsx
+++ b/components/search/search-icons.tsx
@@ -67,6 +67,18 @@ export function BookmarkIcon({ className = "" }: { className?: string }) {
   )
 }
 
+export function ShareIcon({ className = "" }: { className?: string }) {
+  return (
+    <Icon className={className}>
+      <circle cx={18} cy={5} r={3} />
+      <circle cx={6} cy={12} r={3} />
+      <circle cx={18} cy={19} r={3} />
+      <path d="m8.6 10.5 6.8-4" />
+      <path d="m8.6 13.5 6.8 4" />
+    </Icon>
+  )
+}
+
 export function ArrowRightIcon({ className = "" }: { className?: string }) {
   return (
     <Icon className={className}>

--- a/components/search/search-results-client.tsx
+++ b/components/search/search-results-client.tsx
@@ -45,13 +45,15 @@ export function SearchResultsClient({
   const region = searchParams.get("region") ?? ""
   const institution = searchParams.get("institution") ?? undefined
   const institutionLabel = searchParams.get("institutionLabel") ?? undefined
-  const resultSetKey = `${queryFromUrl}|${family ?? ""}|${awardLevel}|${region}|${institution ?? ""}|${institutionLabel ?? ""}`
+  const selectedProgrammeId = searchParams.get("programme") ?? undefined
+  const resultSetKey = `${queryFromUrl}|${family ?? ""}|${awardLevel}|${region}|${institution ?? ""}|${institutionLabel ?? ""}|${selectedProgrammeId ?? ""}`
+  const defaultResultLimit = selectedProgrammeId ? MAX_VISIBLE_RESULTS : INITIAL_RESULT_LIMIT
   const [resultLimitState, setResultLimitState] = useState({
     key: resultSetKey,
-    limit: INITIAL_RESULT_LIMIT,
+    limit: defaultResultLimit,
   })
   const resultLimit =
-    resultLimitState.key === resultSetKey ? resultLimitState.limit : INITIAL_RESULT_LIMIT
+    resultLimitState.key === resultSetKey ? resultLimitState.limit : defaultResultLimit
 
   const filters = useMemo(() => {
     return {
@@ -168,6 +170,7 @@ export function SearchResultsClient({
       updateParams(searchParams, {
         [key]: value,
         ...(key === "institution" ? { institutionLabel: null } : {}),
+        programme: null,
       }),
     )
   }
@@ -180,6 +183,7 @@ export function SearchResultsClient({
         region: null,
         institution: null,
         institutionLabel: null,
+        programme: null,
       }),
     )
   }
@@ -198,6 +202,7 @@ export function SearchResultsClient({
         family: null,
         institution: null,
         institutionLabel: null,
+        programme: null,
       }),
     )
   }
@@ -210,6 +215,7 @@ export function SearchResultsClient({
         family: null,
         institution: null,
         institutionLabel: null,
+        programme: null,
       }),
     )
   }
@@ -272,7 +278,12 @@ export function SearchResultsClient({
             ) : search?.results.length ? (
               <>
                 {search.results.map((programme) => (
-                  <ProgrammeCard key={programme._id} programme={programme} />
+                  <ProgrammeCard
+                    isSelected={programme._id === selectedProgrammeId}
+                    key={programme._id}
+                    programme={programme}
+                    shareUrl={buildProgrammeShareUrl(searchParams, programme._id)}
+                  />
                 ))}
                 <SearchResultsFooter
                   canLoadMore={canLoadMore}
@@ -385,4 +396,11 @@ function LoadingState() {
       ))}
     </div>
   )
+}
+
+function buildProgrammeShareUrl(searchParams: URLSearchParams, programmeId: string) {
+  const nextParams = new URLSearchParams(searchParams.toString())
+  nextParams.set("programme", programmeId)
+
+  return `/search?${nextParams.toString()}`
 }


### PR DESCRIPTION
## Summary
- add a Share action to programme result cards using native share when available and clipboard fallback otherwise
- generate stable /search deep links with a programme query parameter
- auto-highlight and expand the linked programme when a shared URL is opened

## Validation
- bun run typecheck
- bun run lint
- bun run build
- local browser validation on http://localhost:3001: copied a programme share link and reopened it to confirm the linked card auto-expanded