### PR TITLE
Paginate smart search results

### DIFF
--- a/components/search/programme-card.tsx
+++ b/components/search/programme-card.tsx
@@ -15,8 +15,8 @@ import {
 import { api } from "@/convex/_generated/api"
 
 type ProgrammeSearchResult = NonNullable<
-  ReturnType<typeof useQuery<typeof api.programmes.smartSearch>>
->["results"][number]
+  ReturnType<typeof useQuery<typeof api.programmes.smartSearchPaginated>>
+>["page"][number]
 
 export function ProgrammeCard({
   isSelected = false,
@@ -45,7 +45,10 @@ export function ProgrammeCard({
   async function shareProgramme() {
     const shareTitle = `${programme.programmeName} at ${programme.institutionName}`
     const shareText = `Check this course on Kozi Ipi: ${shareTitle}`
-    const absoluteShareUrl = new URL(shareUrl, window.location.origin).toString()
+    const absoluteShareUrl = new URL(
+      shareUrl,
+      window.location.origin
+    ).toString()
 
     if (navigator.share) {
       try {
@@ -70,7 +73,9 @@ export function ProgrammeCard({
   return (
     <article
       className={`group max-w-full scroll-mt-6 overflow-hidden rounded-2xl border bg-white p-4 transition hover:border-brand-blue/35 hover:shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)] sm:p-5 ${
-        isSelected ? "border-brand-blue shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)]" : "border-brand-ink/10"
+        isSelected
+          ? "border-brand-blue shadow-[0_22px_50px_-32px_rgba(29,78,216,0.45)]"
+          : "border-brand-ink/10"
       }`}
       ref={cardRef}
     >
@@ -82,23 +87,27 @@ export function ProgrammeCard({
             logoUrl={programme.institutionLogoUrl}
           />
           <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-[10.5px] font-semibold uppercase tracking-[0.11em] text-brand-ink/45 sm:gap-2 sm:text-[11.5px] sm:tracking-[0.14em]">
-              <span className="min-w-0 max-w-full break-words">{programme.awardLevel}</span>
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-[10.5px] font-semibold tracking-[0.11em] text-brand-ink/45 uppercase sm:gap-2 sm:text-[11.5px] sm:tracking-[0.14em]">
+              <span className="max-w-full min-w-0 break-words">
+                {programme.awardLevel}
+              </span>
               <span className="size-1 rounded-full bg-brand-ink/30" />
-              <span className="min-w-0 max-w-full break-words">{programme.regulator}</span>
+              <span className="max-w-full min-w-0 break-words">
+                {programme.regulator}
+              </span>
               {programme.ownershipType ? (
                 <>
                   <span className="size-1 rounded-full bg-brand-ink/30" />
-                  <span className="min-w-0 max-w-full break-words">
+                  <span className="max-w-full min-w-0 break-words">
                     {programme.ownershipType}
                   </span>
                 </>
               ) : null}
             </div>
-            <h3 className="mt-1.5 line-clamp-2 break-words text-[17px] font-bold tracking-tight">
+            <h3 className="mt-1.5 line-clamp-2 text-[17px] font-bold tracking-tight break-words">
               {programme.programmeName}
             </h3>
-            <p className="mt-0.5 line-clamp-2 break-words text-[13.5px] font-medium text-brand-ink/65">
+            <p className="mt-0.5 line-clamp-2 text-[13.5px] font-medium break-words text-brand-ink/65">
               {programme.institutionName}
             </p>
           </div>
@@ -107,29 +116,33 @@ export function ProgrammeCard({
 
       <div className="mt-4 flex min-w-0 flex-wrap gap-1.5 text-[12px] text-brand-ink/70">
         {programme.region ? (
-          <Tag icon={<PinIcon className="size-3.5 shrink-0" />}>{programme.region}</Tag>
+          <Tag icon={<PinIcon className="size-3.5 shrink-0" />}>
+            {programme.region}
+          </Tag>
         ) : null}
         {programme.duration ? (
           <Tag icon={<ClockIcon className="size-3.5 shrink-0" />}>
             {programme.duration} years
           </Tag>
         ) : null}
-        {programme.feesIfAvailable ? <Tag>{programme.feesIfAvailable}</Tag> : null}
+        {programme.feesIfAvailable ? (
+          <Tag>{programme.feesIfAvailable}</Tag>
+        ) : null}
       </div>
 
       {programme.minimumEntryRequirements ? (
         <div className="mt-4 rounded-xl bg-[#fafafa] p-3.5">
-          <p className="text-[10.5px] font-semibold uppercase tracking-[0.18em] text-brand-ink/40">
+          <p className="text-[10.5px] font-semibold tracking-[0.18em] text-brand-ink/40 uppercase">
             Entry requirements
           </p>
-          <p className="mt-1.5 line-clamp-2 break-words text-[13px] leading-6 text-brand-ink/70">
+          <p className="mt-1.5 line-clamp-2 text-[13px] leading-6 break-words text-brand-ink/70">
             {programme.minimumEntryRequirements}
           </p>
         </div>
       ) : null}
 
       <div className="mt-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <p className="break-words text-[11.5px] text-brand-ink/45">
+        <p className="text-[11.5px] break-words text-brand-ink/45">
           Verified {programme.lastVerifiedDate}
           {programme.needsReview ? " · Needs review" : ""}
         </p>
@@ -162,12 +175,17 @@ export function ProgrammeCard({
 
 function ProgrammeDetails({ programme }: { programme: ProgrammeSearchResult }) {
   const officialSourceHref = normalizeExternalHref(programme.officialSourceUrl)
-  const institutionWebsiteHref = normalizeExternalHref(programme.institutionWebsite)
+  const institutionWebsiteHref = normalizeExternalHref(
+    programme.institutionWebsite
+  )
   const detailRows = [
     { label: "Institution", value: programme.institutionName },
     { label: "Award level", value: programme.awardLevel },
     { label: "Field", value: programme.fieldCategory },
-    { label: "Duration", value: programme.duration ? `${programme.duration} years` : undefined },
+    {
+      label: "Duration",
+      value: programme.duration ? `${programme.duration} years` : undefined,
+    },
     { label: "Region", value: programme.region },
     { label: "Campus", value: programme.campusLocation },
     { label: "Study mode", value: programme.studyMode },
@@ -182,11 +200,14 @@ function ProgrammeDetails({ programme }: { programme: ProgrammeSearchResult }) {
     <div className="mt-4 border-t border-brand-ink/8 pt-4">
       <dl className="grid gap-3 sm:grid-cols-2">
         {detailRows.map((row) => (
-          <div className="min-w-0 rounded-xl bg-brand-ink/[0.035] p-3" key={row.label}>
-            <dt className="text-[10.5px] font-semibold uppercase tracking-[0.16em] text-brand-ink/40">
+          <div
+            className="min-w-0 rounded-xl bg-brand-ink/[0.035] p-3"
+            key={row.label}
+          >
+            <dt className="text-[10.5px] font-semibold tracking-[0.16em] text-brand-ink/40 uppercase">
               {row.label}
             </dt>
-            <dd className="mt-1 break-words text-[13px] leading-5 text-brand-ink/75">
+            <dd className="mt-1 text-[13px] leading-5 break-words text-brand-ink/75">
               {row.value}
             </dd>
           </div>
@@ -199,7 +220,9 @@ function ProgrammeDetails({ programme }: { programme: ProgrammeSearchResult }) {
             <DetailLink href={officialSourceHref}>Official source</DetailLink>
           ) : null}
           {institutionWebsiteHref ? (
-            <DetailLink href={institutionWebsiteHref}>Institution website</DetailLink>
+            <DetailLink href={institutionWebsiteHref}>
+              Institution website
+            </DetailLink>
           ) : null}
         </div>
       ) : null}

--- a/components/search/search-results-client.tsx
+++ b/components/search/search-results-client.tsx
@@ -84,18 +84,19 @@ export function SearchResultsClient({
         query: activeQuery,
         filters: hasFilters ? filters : undefined,
         limit: resultLimit,
+        maxCount: 1000,
       }
     : "skip"
 
   const search = useQuery(api.programmes.smartSearch, searchArgs)
   const isResultsLoading = Boolean(activeQuery) && search === undefined
-  const totalMatches = search?.total ?? search?.results.length ?? 0
   const renderedCount = search?.results.length ?? 0
+  const totalMatches = search?.total ?? 0
   const canLoadMore =
     Boolean(activeQuery) &&
     !isResultsLoading &&
     renderedCount > 0 &&
-    renderedCount < totalMatches &&
+    Boolean(search?.hasMore) &&
     resultLimit < MAX_VISIBLE_RESULTS
 
   const inferredFamily = search?.interpreted.inferredCourseFamily
@@ -240,7 +241,7 @@ export function SearchResultsClient({
             activeQuery={activeQuery}
             inferredFamily={inferredFamily}
             isResultsLoading={isResultsLoading}
-            totalMatches={search?.total ?? search?.results.length}
+            totalMatches={search?.total}
             isCapped={Boolean(search?.capped)}
             resultCount={search?.results.length}
           />

--- a/components/search/search-results-client.tsx
+++ b/components/search/search-results-client.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
-import { useMutation, useQuery } from "convex/react"
+import { useEffect, useMemo, useRef } from "react"
+import { useMutation, usePaginatedQuery, useQuery } from "convex/react"
 import { usePathname, useRouter } from "next/navigation"
 
 import { ProgrammeCard } from "@/components/search/programme-card"
@@ -19,8 +19,8 @@ import { XIcon } from "@/components/search/search-icons"
 import { api } from "@/convex/_generated/api"
 
 const INITIAL_RESULT_LIMIT = 20
-const RESULT_LIMIT_STEP = 20
 const MAX_VISIBLE_RESULTS = 200
+const SEARCH_CANDIDATE_LIMIT = 1000
 
 export function SearchResultsClient({
   initialSearchParams,
@@ -47,18 +47,9 @@ export function SearchResultsClient({
   const institution = searchParams.get("institution") ?? undefined
   const institutionLabel = searchParams.get("institutionLabel") ?? undefined
   const selectedProgrammeId = searchParams.get("programme") ?? undefined
-  const resultSetKey = `${queryFromUrl}|${family ?? ""}|${awardLevel}|${region}|${institution ?? ""}|${institutionLabel ?? ""}|${selectedProgrammeId ?? ""}`
   const defaultResultLimit = selectedProgrammeId
     ? MAX_VISIBLE_RESULTS
     : INITIAL_RESULT_LIMIT
-  const [resultLimitState, setResultLimitState] = useState({
-    key: resultSetKey,
-    limit: defaultResultLimit,
-  })
-  const resultLimit =
-    resultLimitState.key === resultSetKey
-      ? resultLimitState.limit
-      : defaultResultLimit
 
   const filters = useMemo(() => {
     return {
@@ -83,23 +74,29 @@ export function SearchResultsClient({
     ? {
         query: activeQuery,
         filters: hasFilters ? filters : undefined,
-        limit: resultLimit,
-        maxCount: 1000,
+        maxCount: SEARCH_CANDIDATE_LIMIT,
       }
     : "skip"
 
-  const search = useQuery(api.programmes.smartSearch, searchArgs)
-  const isResultsLoading = Boolean(activeQuery) && search === undefined
-  const renderedCount = search?.results.length ?? 0
-  const totalMatches = search?.total ?? 0
+  const searchSummary = useQuery(api.programmes.smartSearchSummary, searchArgs)
+  const paginatedSearch = usePaginatedQuery(
+    api.programmes.smartSearchPaginated,
+    searchArgs,
+    { initialNumItems: defaultResultLimit }
+  )
+  const results = paginatedSearch.results.slice(0, MAX_VISIBLE_RESULTS)
+  const isResultsLoading =
+    Boolean(activeQuery) && paginatedSearch.status === "LoadingFirstPage"
+  const isLoadingMore = paginatedSearch.status === "LoadingMore"
+  const renderedCount = results.length
+  const totalMatches = searchSummary?.total ?? renderedCount
   const canLoadMore =
     Boolean(activeQuery) &&
-    !isResultsLoading &&
+    paginatedSearch.status === "CanLoadMore" &&
     renderedCount > 0 &&
-    Boolean(search?.hasMore) &&
-    resultLimit < MAX_VISIBLE_RESULTS
+    renderedCount < MAX_VISIBLE_RESULTS
 
-  const inferredFamily = search?.interpreted.inferredCourseFamily
+  const inferredFamily = searchSummary?.interpreted.inferredCourseFamily
   const activeFilters = [
     family && {
       key: "family",
@@ -126,16 +123,16 @@ export function SearchResultsClient({
   ].filter(isActiveFilter)
 
   useEffect(() => {
-    if (!submittedQuery || isResultsLoading || !search) {
+    if (!submittedQuery || isResultsLoading || !searchSummary) {
       return
     }
 
-    const resultCount = search.total ?? search.results.length
+    const resultCount = searchSummary.total
     const logKey = JSON.stringify([
       submittedQuery.toLowerCase(),
       filtersJson ?? "",
       resultCount,
-      Boolean(search.capped),
+      searchSummary.capped,
     ])
     if (lastLoggedSearchRef.current === logKey) {
       return
@@ -146,10 +143,16 @@ export function SearchResultsClient({
       query: submittedQuery,
       filtersJson,
       resultCount,
-      resultCountCapped: Boolean(search.capped),
+      resultCountCapped: searchSummary.capped,
       source: "search_page",
     })
-  }, [filtersJson, isResultsLoading, logSearchEvent, search, submittedQuery])
+  }, [
+    filtersJson,
+    isResultsLoading,
+    logSearchEvent,
+    searchSummary,
+    submittedQuery,
+  ])
 
   function routeWith(nextParams: URLSearchParams) {
     const queryString = nextParams.toString()
@@ -209,12 +212,9 @@ export function SearchResultsClient({
   }
 
   function loadMoreResults() {
-    const nextLimit = Math.min(
-      resultLimit + RESULT_LIMIT_STEP,
-      totalMatches,
-      MAX_VISIBLE_RESULTS
+    paginatedSearch.loadMore(
+      Math.min(INITIAL_RESULT_LIMIT, MAX_VISIBLE_RESULTS - renderedCount)
     )
-    setResultLimitState({ key: resultSetKey, limit: nextLimit })
   }
 
   return (
@@ -241,9 +241,9 @@ export function SearchResultsClient({
             activeQuery={activeQuery}
             inferredFamily={inferredFamily}
             isResultsLoading={isResultsLoading}
-            totalMatches={search?.total}
-            isCapped={Boolean(search?.capped)}
-            resultCount={search?.results.length}
+            totalMatches={searchSummary?.total}
+            isCapped={Boolean(searchSummary?.capped)}
+            resultCount={results.length}
           />
 
           {activeFilters.length > 0 ? (
@@ -268,9 +268,9 @@ export function SearchResultsClient({
               <EmptyState />
             ) : isResultsLoading ? (
               <LoadingState />
-            ) : search?.results.length ? (
+            ) : results.length ? (
               <>
-                {search.results.map((programme) => (
+                {results.map((programme) => (
                   <ProgrammeCard
                     isSelected={programme._id === selectedProgrammeId}
                     key={programme._id}
@@ -283,7 +283,8 @@ export function SearchResultsClient({
                 ))}
                 <SearchResultsFooter
                   canLoadMore={canLoadMore}
-                  isCapped={Boolean(search?.capped)}
+                  isCapped={Boolean(searchSummary?.capped)}
+                  isLoadingMore={isLoadingMore}
                   onLoadMore={loadMoreResults}
                   renderedCount={renderedCount}
                   totalMatches={totalMatches}
@@ -302,12 +303,14 @@ export function SearchResultsClient({
 function SearchResultsFooter({
   canLoadMore,
   isCapped,
+  isLoadingMore,
   onLoadMore,
   renderedCount,
   totalMatches,
 }: {
   canLoadMore: boolean
   isCapped: boolean
+  isLoadingMore: boolean
   onLoadMore: () => void
   renderedCount: number
   totalMatches: number
@@ -318,13 +321,14 @@ function SearchResultsFooter({
         Showing {renderedCount} of {totalMatches}
         {isCapped ? "+" : ""} matches
       </p>
-      {canLoadMore ? (
+      {canLoadMore || isLoadingMore ? (
         <button
-          className="rounded-full border border-brand-ink/15 px-5 py-2.5 text-[13px] font-semibold text-brand-ink transition hover:border-brand-blue hover:bg-brand-blue hover:text-white"
+          className="rounded-full border border-brand-ink/15 px-5 py-2.5 text-[13px] font-semibold text-brand-ink transition hover:border-brand-blue hover:bg-brand-blue hover:text-white disabled:cursor-wait disabled:opacity-60"
+          disabled={isLoadingMore}
           onClick={onLoadMore}
           type="button"
         >
-          Load more
+          {isLoadingMore ? "Loading..." : "Load more"}
         </button>
       ) : null}
     </div>

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as programmeSearch_display from "../programmeSearch/display.js";
 import type * as programmeSearch_filters from "../programmeSearch/filters.js";
 import type * as programmeSearch_interpret from "../programmeSearch/interpret.js";
 import type * as programmeSearch_matching from "../programmeSearch/matching.js";
+import type * as programmeSearch_pagination from "../programmeSearch/pagination.js";
 import type * as programmeSearch_ranking from "../programmeSearch/ranking.js";
 import type * as programmeSearch_search from "../programmeSearch/search.js";
 import type * as programmes from "../programmes.js";
@@ -37,6 +38,7 @@ declare const fullApi: ApiFromModules<{
   "programmeSearch/filters": typeof programmeSearch_filters;
   "programmeSearch/interpret": typeof programmeSearch_interpret;
   "programmeSearch/matching": typeof programmeSearch_matching;
+  "programmeSearch/pagination": typeof programmeSearch_pagination;
   "programmeSearch/ranking": typeof programmeSearch_ranking;
   "programmeSearch/search": typeof programmeSearch_search;
   programmes: typeof programmes;

--- a/convex/programmeSearch/pagination.ts
+++ b/convex/programmeSearch/pagination.ts
@@ -1,0 +1,41 @@
+export type SearchPage<T> = {
+  cursor: string | null
+  hasMore: boolean
+  nextCursor: string | null
+  results: T[]
+  total: number
+}
+
+export function sliceSearchPage<T>(
+  results: T[],
+  args: {
+    cursor?: string | null
+    pageSize: number
+  }
+): SearchPage<T> {
+  const offset = parseSearchCursor(args.cursor)
+  const page = results.slice(offset, offset + args.pageSize)
+  const nextOffset = offset + page.length
+  const hasMore = nextOffset < results.length
+
+  return {
+    cursor: args.cursor ?? null,
+    hasMore,
+    nextCursor: hasMore ? formatSearchCursor(nextOffset) : null,
+    results: page,
+    total: results.length,
+  }
+}
+
+function parseSearchCursor(cursor?: string | null) {
+  if (!cursor) return 0
+
+  const offset = Number.parseInt(cursor, 10)
+  if (!Number.isFinite(offset) || offset < 0) return 0
+
+  return Math.trunc(offset)
+}
+
+function formatSearchCursor(offset: number) {
+  return String(offset)
+}

--- a/convex/programmes.ts
+++ b/convex/programmes.ts
@@ -11,6 +11,7 @@ import {
 } from "./programmeSearch/filters"
 import { interpretProgrammeQuery } from "./programmeSearch/interpret"
 import { matchesProgrammeFilters } from "./programmeSearch/matching"
+import { sliceSearchPage } from "./programmeSearch/pagination"
 import { isNursingIntent, rankProgrammes } from "./programmeSearch/ranking"
 import { queryProgrammesBySearchText } from "./programmeSearch/search"
 
@@ -78,6 +79,64 @@ export const smartSearch = query({
       total: rankedResults.length,
       capped,
       hasMore: rankedResults.length > visibleResults.length,
+    }
+  },
+})
+
+export const smartSearchSummary = query({
+  args: {
+    query: v.string(),
+    filters: filtersValidator,
+    formFourOnly: v.optional(v.boolean()),
+    maxCount: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const { interpreted, rankedResults, capped } =
+      await getSmartSearchCandidates(ctx, {
+        query: args.query,
+        filters: args.filters,
+        formFourOnly: args.formFourOnly,
+        maxCount: args.maxCount,
+      })
+
+    return {
+      interpreted,
+      total: rankedResults.length,
+      capped,
+    }
+  },
+})
+
+export const smartSearchPaginated = query({
+  args: {
+    query: v.string(),
+    filters: filtersValidator,
+    formFourOnly: v.optional(v.boolean()),
+    paginationOpts: paginationOptsValidator,
+    maxCount: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const pageSize = clampCount(
+      args.paginationOpts.numItems,
+      DEFAULT_RESULT_LIMIT,
+      MAX_VISIBLE_RESULT_LIMIT
+    )
+    const { rankedResults } = await getSmartSearchCandidates(ctx, {
+      query: args.query,
+      filters: args.filters,
+      formFourOnly: args.formFourOnly,
+      limit: pageSize,
+      maxCount: args.maxCount,
+    })
+    const page = sliceSearchPage(rankedResults, {
+      cursor: args.paginationOpts.cursor,
+      pageSize,
+    })
+
+    return {
+      page: formatProgrammeSearchResults(page.results),
+      isDone: !page.hasMore,
+      continueCursor: page.nextCursor ?? page.cursor ?? "",
     }
   },
 })

--- a/scripts/test-search-contracts.ts
+++ b/scripts/test-search-contracts.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url"
 
 import { matchesField } from "../lib/domain/taxonomy"
 import { interpretProgrammeQuery } from "../convex/programmeSearch/interpret"
+import { sliceSearchPage } from "../convex/programmeSearch/pagination"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = join(__dirname, "..")
@@ -37,58 +38,125 @@ function assert(condition: unknown, message: string): asserts condition {
 const interpretedNursing = interpretProgrammeQuery("nataka kuwa nurse")
 assert(
   interpretedNursing.inferredCourseFamily === "health",
-  'Expected "nataka kuwa nurse" to infer the health course family.',
+  'Expected "nataka kuwa nurse" to infer the health course family.'
 )
 
 const interpretedEngineering = interpretProgrammeQuery("civil engineering")
 assert(
   interpretedEngineering.inferredCourseFamily === "engineering",
-  'Expected "civil engineering" to infer the engineering course family.',
+  'Expected "civil engineering" to infer the engineering course family.'
 )
 
 assert(
   matchesField("technical automotive engineering", "Engineering"),
-  "Engineering field taxonomy should match technical/automotive text.",
+  "Engineering field taxonomy should match technical/automotive text."
 )
 assert(
   !matchesField("technical automotive engineering", "Business"),
-  "Business field taxonomy must not match engineering-only text.",
+  "Business field taxonomy must not match engineering-only text."
 )
 
-const institutions = readJsonl<Institution>(join(root, "data/processed/institutions.jsonl"))
-const programmes = readJsonl<Programme>(join(root, "data/processed/programmes.jsonl"))
+const pagedFixtures = Array.from({ length: 45 }, (_, index) => ({
+  id: `programme-${index + 1}`,
+}))
+const firstSearchPage = sliceSearchPage(pagedFixtures, {
+  cursor: null,
+  pageSize: 20,
+})
+assert(
+  firstSearchPage.total === 45,
+  "Search pagination should expose the full total."
+)
+assert(
+  firstSearchPage.results.length === 20,
+  "First search page should respect page size."
+)
+assert(firstSearchPage.hasMore, "First search page should report more results.")
+assert(
+  firstSearchPage.nextCursor === "20",
+  "First search page should continue from offset 20."
+)
+
+const secondSearchPage = sliceSearchPage(pagedFixtures, {
+  cursor: firstSearchPage.nextCursor,
+  pageSize: 20,
+})
+assert(
+  secondSearchPage.results[0]?.id === "programme-21",
+  "Second search page should start after the first page."
+)
+assert(
+  !firstSearchPage.results.some((result) =>
+    secondSearchPage.results.some((nextResult) => nextResult.id === result.id)
+  ),
+  "Search pagination pages must not overlap."
+)
+assert(
+  secondSearchPage.hasMore,
+  "Second search page should report a final page."
+)
+
+const finalSearchPage = sliceSearchPage(pagedFixtures, {
+  cursor: secondSearchPage.nextCursor,
+  pageSize: 20,
+})
+assert(
+  finalSearchPage.results.length === 5,
+  "Final search page should return remaining results."
+)
+assert(!finalSearchPage.hasMore, "Final search page should be exhausted.")
+assert(
+  finalSearchPage.nextCursor === null,
+  "Final search page should not return a cursor."
+)
+
+const institutions = readJsonl<Institution>(
+  join(root, "data/processed/institutions.jsonl")
+)
+const programmes = readJsonl<Programme>(
+  join(root, "data/processed/programmes.jsonl")
+)
 const institutionsByName = new Map(
-  institutions.map((institution) => [institution.normalizedInstitutionName, institution]),
+  institutions.map((institution) => [
+    institution.normalizedInstitutionName,
+    institution,
+  ])
 )
 
-const programmesWithLogo = programmes.filter((programme) => programme.institutionLogoUrl)
+const programmesWithLogo = programmes.filter(
+  (programme) => programme.institutionLogoUrl
+)
 assert(
   programmesWithLogo.length > 0,
-  "Expected at least one processed programme to carry a denormalized institution logo URL.",
+  "Expected at least one processed programme to carry a denormalized institution logo URL."
 )
 
 for (const programme of programmesWithLogo) {
-  const institution = institutionsByName.get(programme.normalizedInstitutionName)
+  const institution = institutionsByName.get(
+    programme.normalizedInstitutionName
+  )
   assert(
     institution,
-    `Missing processed institution for programme ${programme.normalizedInstitutionName}.`,
+    `Missing processed institution for programme ${programme.normalizedInstitutionName}.`
   )
   assert(
     institution.logoStatus === "verified",
-    `Programme logo should only be denormalized from verified institutions: ${programme.normalizedInstitutionName}.`,
+    `Programme logo should only be denormalized from verified institutions: ${programme.normalizedInstitutionName}.`
   )
   assert(
     programme.institutionLogoUrl === institution.logoUrl,
-    `Programme logo URL drifted from institution logo URL for ${programme.normalizedInstitutionName}.`,
+    `Programme logo URL drifted from institution logo URL for ${programme.normalizedInstitutionName}.`
   )
 }
 
-const programmesWithWebsite = programmes.filter((programme) => programme.institutionWebsite)
+const programmesWithWebsite = programmes.filter(
+  (programme) => programme.institutionWebsite
+)
 assert(
   programmesWithWebsite.length > 0,
-  "Expected at least one processed programme to carry a denormalized institution website.",
+  "Expected at least one processed programme to carry a denormalized institution website."
 )
 
 console.log(
-  `Search contract checks passed for ${programmesWithLogo.length} logo-bearing programmes and ${programmesWithWebsite.length} programmes with websites.`,
+  `Search contract checks passed for ${programmesWithLogo.length} logo-bearing programmes and ${programmesWithWebsite.length} programmes with websites.`
 )


### PR DESCRIPTION
## Summary
- replace the growing `limit` search UI with Convex paginated loading
- add `programmes:smartSearchPaginated` for page/cursor loading and `programmes:smartSearchSummary` for total/family metadata
- keep the existing smart ranking/dedupe path as the shared source of truth
- add a shared search pagination helper with no-overlap cursor tests
- deployed production Convex functions so the live site can call the new pagination API

Closes #17.

## Why this is better
- Load more now requests the next page instead of refetching the first 20, then 40, then 60 results
- the client renders an appended paginated list instead of repeatedly replacing a larger list
- totals and category metadata come from a summary query, while cards come from the paginated query

## Verification
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run convex:deploy`
- production `smartSearchSummary({ query: "Hotel management", maxCount: 1000 })` returned `total: 130`
- production `smartSearchPaginated` returned page cursors `"2"` then `"4"` for successive two-item pages
