### PR TITLE
ui(search): add accessibility labels to search filters

### DIFF
--- a/components/search/search-filters.tsx
+++ b/components/search/search-filters.tsx
@@ -26,12 +26,13 @@ export function SearchFilters({
   setFilter,
 }: SearchFiltersProps) {
   return (
-    <aside className="h-fit lg:sticky lg:top-6">
+    <aside className="h-fit lg:sticky lg:top-6" aria-label="Search filters">
       <div className="rounded-2xl border border-brand-ink/10 bg-white">
         <div className="flex items-center justify-between border-b border-brand-ink/8 px-5 py-4">
           <p className="text-[13px] font-semibold tracking-tight">Filters</p>
           {activeFilters.length > 0 ? (
             <button
+              aria-label="Clear all filters"
               className="text-[12px] font-medium text-brand-blue hover:underline"
               onClick={clearAllFilters}
               type="button"
@@ -42,7 +43,7 @@ export function SearchFilters({
         </div>
 
         <FilterSection title="Field of study" hint="Eneo la masomo">
-          <div className="grid grid-cols-2 gap-1.5">
+          <div className="grid grid-cols-2 gap-1.5" role="group" aria-label="Field of study options">
             {courseFamilies.map((courseFamily) => (
               <button
                 aria-pressed={family === courseFamily.key}
@@ -65,7 +66,7 @@ export function SearchFilters({
         </FilterSection>
 
         <FilterSection title="Level" hint="Ngazi ya kozi">
-          <div className="grid grid-cols-1 gap-1">
+          <div className="grid grid-cols-1 gap-1" role="group" aria-label="Award level options">
             {awardLevels.map((level) => (
               <button
                 aria-pressed={awardLevel === level.value}

--- a/convex/institutions.ts
+++ b/convex/institutions.ts
@@ -86,14 +86,13 @@ export const browse = query({
   },
   handler: async (ctx, args) => {
     const limit = Math.min(Math.max(args.limit ?? 80, 1), 240)
-    // Use indexed pagination to fetch up to 1000 documents efficiently
-    const page = await ctx.db
+    const institutions = await ctx.db
       .query("institutions")
       .withIndex("by_programmeCount")
       .order("desc")
-      .paginate({ numItems: 1000, cursor: null })
-    const institutionsPage = page.page
-    const browseInstitutions = institutionsPage.map(toBrowseInstitution)
+      // TODO: Replace this capped scan with indexed pagination before the catalogue exceeds 1000 institutions.
+      .take(1000)
+    const browseInstitutions = institutions.map(toBrowseInstitution)
     const filters = args.filters
     const query = normalize(filters?.query)
     const types = new Set(filters?.types ?? [])

--- a/convex/institutions.ts
+++ b/convex/institutions.ts
@@ -86,13 +86,14 @@ export const browse = query({
   },
   handler: async (ctx, args) => {
     const limit = Math.min(Math.max(args.limit ?? 80, 1), 240)
-    const institutions = await ctx.db
+    // Use indexed pagination to fetch up to 1000 documents efficiently
+    const page = await ctx.db
       .query("institutions")
       .withIndex("by_programmeCount")
       .order("desc")
-      // TODO: Replace this capped scan with indexed pagination before the catalogue exceeds 1000 institutions.
-      .take(1000)
-    const browseInstitutions = institutions.map(toBrowseInstitution)
+      .paginate({ numItems: 1000, cursor: null })
+    const institutionsPage = page.page
+    const browseInstitutions = institutionsPage.map(toBrowseInstitution)
     const filters = args.filters
     const query = normalize(filters?.query)
     const types = new Set(filters?.types ?? [])


### PR DESCRIPTION

- Add an aria-label to the search filters aside  
- Label the "Clear all" action for screen readers  
- Group field-of-study and award-level controls with accessible group labels  
